### PR TITLE
Fix payload extract in github event controller

### DIFF
--- a/github_event_webhook/controllers/github.py
+++ b/github_event_webhook/controllers/github.py
@@ -51,9 +51,18 @@ class GithubEvent(http.Controller):
             _logger.info(message)
             return Response(message, status=401)
 
-        event = request.env['github.event'].sudo().create({
-            'payload': json.dumps(data),
-        })
+        json_payload = self._get_json_payload(data)
+        event = self._create_event(json_payload)
         event.with_delay().process_job()
 
         return Response(status=201)
+
+    @staticmethod
+    def _get_json_payload(data):
+        return data['payload']
+
+    @staticmethod
+    def _create_event(json_payload):
+        return request.env['github.event'].sudo().create({
+            'payload': json_payload,
+        })

--- a/github_event_webhook/tests/test_github_controller.py
+++ b/github_event_webhook/tests/test_github_controller.py
@@ -27,10 +27,11 @@ class TestPullRequest(common.SavepointCase):
     def setUp(self):
         super().setUp()
         self.controller = GithubEvent()
-        self.data = OrderedDict([
+        self.payload = OrderedDict([
             ('number', 1),
             ('action', 'created'),
         ])
+        self.data = {'payload': json.dumps(self.payload)}
         encoded_data = url_encode(self.data)
         signature = make_github_signature(encoded_data, self.token)
         self.headers = {GITHUB_SIGNATURE_HEADER: signature}
@@ -51,7 +52,7 @@ class TestPullRequest(common.SavepointCase):
 
         event = self._get_created_event()
         assert event.payload
-        assert json.loads(event.payload) == self.data
+        assert json.loads(event.payload) == self.payload
 
     def test_if_token_not_passed__return_error_401(self):
         del self.headers[GITHUB_SIGNATURE_HEADER]


### PR DESCRIPTION
https://www.numigi.com/web#id=18824&action=292&active_id=600&model=project.task&view_type=form&menu_id=200

The payload is passed by github as a dict containing {'payload': json_of_the_payload}.
2 months ago, this behavior from github was different.

The payload was passed directly as the form data.
Now the form data contains one field 'payload' which contains a json encoded version of the payload.